### PR TITLE
allow mouse scrolling inside tmux panes

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -49,6 +49,9 @@ set -g status-right ''
 # increase scrollback lines
 set -g history-limit 10000
 
+# allow mouse scrolling inside tmux panes
+set -g mode-mouse on
+
 # prefix -> back-one-character
 bind-key C-b send-prefix
 # prefix-2 -> forward-incremental-history-search


### PR DESCRIPTION
@nmeans I tested this out on a pairing box and it made scrolling with a mouse/trackpad inside of the currently selected pane work as one might expect.