### PR TITLE
Add syntax highlighting and linting for API Blueprint

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -45,6 +45,7 @@ Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/tComment'
 Plug 'christoomey/vim-tmux-navigator'
+Plug 'kylef/apiblueprint.vim'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
Note that linting only works if Syntastic (https://github.com/vim-syntastic/syntastic, included in dotfiles) and https://github.com/apiaryio/drafter are also installed.